### PR TITLE
Remove six from the svgcheck setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,40 +37,26 @@ install:
     - ./install.sh
 
 script:
-  - $PIP install -r requirements.txt
   - export PATH=$PATH:${HOME}/build/ietf-tools/RfcEditor/$BAP
   - pwd
   - mkdir dist
   - python --version
   - cd rfctools_common && $PYTHON setup.py --quiet install
   - pwd
-  - cd rfctools_common && $PYTHON test.py
-  - cd ../../svgcheck
-  - $PYTHON setup.py --quiet install
-  - cd svgcheck
-  - $PYTHON test.py
-  - cd ../../rfclint
-  - $PYTHON setup.py --quiet install
-  - cd rfclint
-  - $PYTHON test.py
-  - cd ../../xmldiff
-  - $PYTHON setup.py --quiet install
+  - cd ../rfclint && $PYTHON setup.py --quiet install
+  - cd ../svgcheck && $PYTHON setup.py --quiet install
+  - cd ../xmldiff && $PYTHON setup.py --quiet install
   - $PYTHON setup.py --quiet bdist_wheel
-  - cp dist/* ../dist
-  - cd Test
-  - $PYTHON test.py
+
+  - cd ..
+  - $PIP install -r requirements.txt
+  - cd rfctools_common/rfctools_common && $PYTHON test.py
+  - cd ../..
+  - cd svgcheck/svgcheck && $PYTHON test.py
+  - cd ../..
+  - cd rfclint/rfclint && $PYTHON test.py
+  - cd ../..
+  - cd xmldiff/test && $PYTHON test.py
   - cd ../..
   - ls dist
-
-before_deploy:
-  openssl aes-256-cbc -K $encrypted_b97c0a903367_key -iv $encrypted_b97c0a903367_iv -in deploy_key2.enc -out deploy_key -d
- 
-deploy:
-  provider: releases
-  api_key: "GITHUB AUTH TOKEN"
-  file_glob: true
-  file: dist/*
-  skip_cleanup: true
-  on:
-    tags: true
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
   - cd ../..
   - cd rfclint/rfclint && $PYTHON test.py
   - cd ../..
-  - cd xmldiff/test && $PYTHON test.py
+  - cd xmldiff/Test && $PYTHON test.py
   - cd ../..
+  - pwd
   - ls dist
-    

--- a/rfclint/rfclint/Results/version.out
+++ b/rfclint/rfclint/Results/version.out
@@ -1,3 +1,3 @@
 rfclint = 0.6.0
-rfctools_common = 0.6.0
+rfctools_common = 0.6.1
 svgcheck = 0.6.0

--- a/rfctools_common/changelog
+++ b/rfctools_common/changelog
@@ -1,3 +1,9 @@
+rfctools-common (0.6.1) distribhution(s); urgency=low
+
+	* Remove module six from the setup
+
+-- Jim Schaad <ietf@augustcellars.com>  Fri 24 Jan 2020 12:00:00 -0700
+
 rfctools-common (0.6.0) distribhution(s); urgency=low
 
 	* Update to the latest set of schema files

--- a/rfctools_common/rfctools_common/__init__.py
+++ b/rfctools_common/rfctools_common/__init__.py
@@ -3,6 +3,6 @@
 # --------------------------------------------------
 
 # Static values
-__version__  = '0.6.0'
+__version__  = '0.6.1'
 NAME         = 'rfctools_common'
 VERSION      = [ int(i) if i.isdigit() else i for i in __version__.split('.') ]

--- a/rfctools_common/setup.py
+++ b/rfctools_common/setup.py
@@ -8,10 +8,6 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 import rfctools_common
-import six
-
-if six.PY3:
-    unicode = str
 
 here = path.abspath(path.dirname(__file__))
 
@@ -34,7 +30,7 @@ def parse(changelog):
     sig_line = "^ ?-- ([^<]+) <([^>]+)>  (.*?) *$"
 
     entries = []
-    if isinstance(changelog, str) or isinstance(changelog, unicode):
+    if isinstance(changelog, type('')):
         changelog = open(changelog, mode='rU', encoding='utf-8')
     for line in changelog:
         if re.match(ver_line, line):

--- a/svgcheck/svgcheck/Results/version.out
+++ b/svgcheck/svgcheck/Results/version.out
@@ -1,2 +1,2 @@
 svgcheck = 0.6.0
-rfctools_common = 0.6.0
+rfctools_common = 0.6.1

--- a/xmldiff/Test/Results/Version.out
+++ b/xmldiff/Test/Results/Version.out
@@ -1,2 +1,2 @@
 xmldiff = 0.6.1
-rfctools_common = 0.6.0
+rfctools_common = 0.6.1


### PR DESCRIPTION
If six is not installed, then the svg setup can not use it.
Re-order the check script so we don't install things before it is absolutely necesary.